### PR TITLE
Fix example and parrallelize workshop downloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,21 +9,21 @@ services:
       - "7777"
     environment:
       # Download the Calamity mod and CalamityMusic mod.
-      - TMOD_AUTODOWNLOAD=2824688072,2824688266
+      - "TMOD_AUTODOWNLOAD=2824688072,2824688266"
       # Enable the Calamity mod and CalamityMusic mod.
-      - TMOD_LOADMODS=2824688072,2824688266
+      - "TMOD_LOADMODS=2824688072,2824688266"
       # Shutdown Message and Autosave Interval (In Minutes)
-      - TMOD_SHUTDOWN_MESSAGE="Goodbye!"
-      - TMOD_AUTOSAVE_INTERVAL="15"
+      - "TMOD_SHUTDOWN_MESSAGE=Goodbye!"
+      - "TMOD_AUTOSAVE_INTERVAL=15"
       # Server Settings
-      - TMOD_MOTD="Welcome to my tModLoader Server!"
-      - TMOD_PASS="secret"
-      - TMOD_MAXPLAYERS="16"
-      - TMOD_WORLDNAME="Earth"
-      - TMOD_WORLDSIZE="2"
-      - TMOD_WORLDSEED="not the bees!"
+      - "TMOD_MOTD=Welcome to my tModLoader Server!"
+      - "TMOD_PASS=secret"
+      - "TMOD_MAXPLAYERS=16"
+      - "TMOD_WORLDNAME=Earth"
+      - "TMOD_WORLDSIZE=2"
+      - "TMOD_WORLDSEED=not the bees!"
       # If set to "Yes", it is expected to have a config.txt mapped. The Server Settings above will be ignored.
-      - TMOD_USECONFIGFILE="No"
+      - "TMOD_USECONFIGFILE=No"
 
     volumes:
       - "/path/to/worlds/file:/root/.local/share/Terraria/tModLoader/Worlds"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,14 +42,9 @@ if test -z "${TMOD_AUTODOWNLOAD}" ; then
     echo -e "For  more information, please see the Github README.\n\n"
     sleep 5s
 else
-    echo -e " [*] Downloading Mods specified in the TMOD_AUTODOWNLOAD Environment Variable..."
-    # Convert the Comma Separated list of Mod IDs to a iterable list, and then call SteamCMD to download them one by one.
-    echo -e $TMOD_AUTODOWNLOAD | tr "," "\n" | while read LINE
-    do
-        echo -e ""
-        echo -e " [*] Downloading Mod ID: $LINE\n\n"
-        /root/terraria-server/steamcmd.sh +force_install_dir /root/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 $LINE +quit &
-    done
+    echo -e " [*] Downloading Mods specified in the TMOD_AUTODOWNLOAD Environment Variable. This may hand a while depending on the number of mods..."
+    # Convert the Comma Separated list of Mod IDs to a list of SteamCMD commands and call SteamCMD to download them all.
+    /root/terraria-server/steamcmd.sh +force_install_dir /root/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 `echo -e $TMOD_AUTODOWNLOAD | sed 's/,/ +workshop_download_item 1281930 /g'` +quit
     echo -e " [*] Finished downloading mods.\n\n"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ else
     do
         echo -e ""
         echo -e " [*] Downloading Mod ID: $LINE\n\n"
-        /root/terraria-server/steamcmd.sh +force_install_dir /root/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 $LINE +quit
+        /root/terraria-server/steamcmd.sh +force_install_dir /root/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 $LINE +quit &
     done
     echo -e " [*] Finished downloading mods.\n\n"
 fi


### PR DESCRIPTION
The quote placement in the docker compose example caused the environment variable values to actually include quotes.
Steam workshop downloads should now happen in parrallel massively reducing startup time.