### PR TITLE
Complete Config Rewrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,71 @@ ENV TMOD_AUTODOWNLOAD=""
 # Example format: 2824688072,2824688266,2835214226
 ENV TMOD_ENABLEDMODS=""
 
+#--------- CONFIG SECTION --------- #
 # The following environment variables will configure common settings for the tModLoader server.
-ENV TMOD_MOTD="A tModLoader server powered by Docker!"
-ENV TMOD_PASS="docker"
-ENV TMOD_MAXPLAYERS="8"
-ENV TMOD_WORLDNAME="Docker"
-ENV TMOD_WORLDSIZE="3"
-ENV TMOD_WORLDSEED="Docker"
 
+# motd
+ENV TMOD_MOTD="A tModLoader server powered by Docker!"
+# password
+ENV TMOD_PASS="docker"
+# maxplayers
+ENV TMOD_MAXPLAYERS="8"
+# worldname
+ENV TMOD_WORLDNAME="Docker"
+# autocreate
+ENV TMOD_WORLDSIZE="3"
+# seed
+ENV TMOD_WORLDSEED="Docker"
+# difficulty
+ENV TMOD_DIFFICULTY="1"
+# secure
+ENV TMOD_SECURE="0"
+# language
+ENV TMOD_LANGUAGE="en-US"
+# npcstream
+ENV TMOD_NPCSTREAM="60"
+# upnp
+ENV TMOD_UPNP="0"
+# priority
+ENV TMOD_PRIORITY="1"
+
+# JOURNEY MODE POWER PERMISSIONS
+
+# journeypermission_time_setfrozen
+ENV TMOD_JOURNEY_SETFROZEN="0"
+# journeypermission_time_setdawn
+ENV TMOD_JOURNEY_SETDAWN="0"
+# journeypermission_time_setnoon
+ENV TMOD_JOURNEY_SETNOON="0"
+# journeypermission_time_setdusk
+ENV TMOD_JOURNEY_SETDUSK="0"
+# journeypermission_time_setmidnight
+ENV TMOD_JOURNEY_SETMIDNIGHT="0"
+# journeypermission_godmode
+ENV TMOD_JOURNEY_GODMODE="0"
+# journeypermission_wind_setstrength
+ENV TMOD_JOURNEY_WIND_STRENGTH="0"
+# journeypermission_rain_setstrength
+ENV TMOD_JOURNEY_RAIN_STRENGTH="0"
+# journeypermission_time_setspeed
+ENV TMOD_JOURNEY_TIME_SPEED="0"
+# journeypermission_rain_setfrozen
+ENV TMOD_JOURNEY_RAIN_FROZEN="0"
+# journeypermission_wind_setfrozen
+ENV TMOD_JOURNEY_WIND_FROZEN="0"
+# journeypermission_increaseplacementrange
+ENV TMOD_JOURNEY_PLACEMENT_RANGE="0"
+# journeypermission_setdifficulty
+ENV TMOD_JOURNEY_SET_DIFFICULTY="0"
+# journeypermission_biomespread_setfrozen
+ENV TMOD_JOURNEY_BIOME_SPREAD="0"
+# journeypermission_setspawnrate
+ENV TMOD_JOURNEY_SPAWN_RATE="0"
+
+# [!!!] The section for using a config file has been deprecated in favor of the environment variable approach.
 # Loading a configuration file expects a proper Terraria config file to be mapped to /root/terraria-server/serverconfig.txt
 # Set this to "Yes" if you would rather use a config file instead of the above settings.
-ENV TMOD_USECONFIGFILE="No"
+# ENV TMOD_USECONFIGFILE="No"
 
 EXPOSE 7777
 
@@ -62,7 +116,8 @@ RUN mkdir /root/.local/share/Terraria/tModLoader/Mods
 COPY entrypoint.sh .
 COPY inject.sh /usr/local/bin/inject
 COPY autosave.sh .
+COPY prepare-config.sh .
 
-RUN chmod +x entrypoint.sh /usr/local/bin/inject autosave.sh
+RUN chmod +x entrypoint.sh /usr/local/bin/inject autosave.sh prepare-config.sh
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV TMOD_AUTODOWNLOAD=""
 # Example format: 2824688072,2824688266,2835214226
 ENV TMOD_ENABLEDMODS=""
 
+# If you want to specify your own config, set the following to "Yes".
+ENV TMOD_USECONFIGFILE="No"
+
 #--------- CONFIG SECTION --------- #
 # The following environment variables will configure common settings for the tModLoader server.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:latest
 
 # The TMOD Version. Ensure that you follow the correct format. Version releases can be found at https://github.com/tModLoader/tModLoader/releases if you're lost.
-ARG TMOD_VERSION=v2022.09.47.46
+ARG TMOD_VERSION=v2022.09.47.47
 
 # The shutdown message is broadcast to the game chat when the container was stopped from the host.
 ENV TMOD_SHUTDOWN_MESSAGE="Server is shutting down NOW!"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Create a directory on Host machine to house the world file as well as backups.
 mkdir /path/to/worlds/directory
 export TMOD_WORLDS=/path/to/worlds/directory
 ```
+
+Then you will need to specify your TMOD_WORLDS variable when running the container, like the following example.
+
+```bash
+-v $TMOD_WORLDS:/root/.local/share/Terraria/tModLoader/Worlds
+```
+
 _You can omit this, though the worlds will not be saved after your container shuts down! You have been warned._
 
 ---
@@ -71,17 +78,36 @@ This is optional, but including this in your configuration will **greatly reduce
 mkdir /path/to/workshop/directory
 export TMOD_WORKSHOP=/path/to/workshop/directory
 ```
+
+Then you will need to specify your TMOD_WORKSHOP variable when running the container, like the following example.
+
+```bash
+-v $TMOD_WORKSHOP:/root/terraria-server/workshop-mods
+```
+
 ---
 
-### Server Configuration File (Optional)
-If you would rather have the server read from a configuration file, you may map the configuration file directly. Be sure to set the `TMOD_USECONFIGFILE` environment variable to a value of `YES`.
+### _(DEPRECRATED)_ Server Configuration File (Optional)
+If you would rather have the server read from a configuration file you've created, you may map the configuration file directly. Be sure to set the `TMOD_USECONFIGFILE` environment variable to a value of `YES`.
 
 Refer to the [Terraria Server Documentation]((https://terraria.fandom.com/wiki/Server#Server_config_file)) on how to setup a configuration file.
 
+
 ```bash
-# Exporting the path to the serverconfig.txt to a variable
-export TMOD_CONFIGFILE=/path/to/serverconfig.txt
+# Exporting the path to the customconfig.txt to a variable
+export TMOD_CONFIGFILE=/path/to/customconfig.txt
 ```
+
+Then you will need to specify your TMOD_CONFIGFILE variable when running the container, like the following example.
+
+This container expects the file to be at this exact path in the container: `/root/terraria-server/customconfig.txt`.
+
+```bash
+-v $TMOD_CONFIGFILE:/root/terraria-server/customconfig.txt \
+```
+
+_Please note, while you are able to specify a config file, it has been deprecated as of April 2023 due to updates to the Environment Variable handling._
+
 ---
 
 ## Downloading Mods
@@ -118,21 +144,49 @@ Additionally, you may at any time remove a mod from the `TMOD_ENABLEDMODS` varia
 ---
 
 # Environment Variables
-The following are all of the environment variables that are supported by the container.
+The following are all of the environment variables that are supported by the container. These handle server functionality and Terraria server configurations.
 
 | Variable      | Default Value | Description |
 | ----------- | ----------- | ----------- |
 | TMOD_SHUTDOWN_MESSAGE | Server is shutting down NOW! | The message which will be sent to the in-game chat upon container shutdown.
 | TMOD_AUTOSAVE_INTERVAL   | 10 | The autosave interval (in minutes) in which the World will be saved.
 | TMOD_AUTODOWNLOAD | N/A | A Comma Separated list of Workshop Mod IDs to download from Steam upon container startup.
-| TMOD_ENABLEDMODS | N/A | A Comma Separated list of Workshop Mod IDs to enable on the tModLoader server upon startup. 
+| TMOD_ENABLEDMODS | N/A | A Comma Separated list of Workshop Mod IDs to enable on the tModLoader server upon startup.
+| TMOD_USECONFIGFILE | No | If you wish to use a config file to specify server settings, set this variable to "Yes". Please note, this has been deprecated.
 | TMOD_MOTD | A tModLoader server powered by Docker! | The Message of the Day which prints in the chat upon joining the server.
 | TMOD_PASS | docker | The password players must supply to join the server. Set this variable to "N/A" to disable requiring a password on join. (Not Recommended)
 | TMOD_MAXPLAYERS | 8 | The maximum number of players which can join the server at once.
 | TMOD_WORLDNAME | Docker | The name of the world file. This is seen in-game as well as will be used for the name of the .WLD file.
-| TMOD_WORLDSIZE | 3 | When generating a new world, this variable will be used to designate the size. 1 = Small, 2 = Medium, 3 = Large
+| TMOD_WORLDSIZE | 3 | When generating a new world (and only when generating a new world), this variable will be used to designate the size. 1 = Small, 2 = Medium, 3 = Large
 | TMOD_WORLDSEED | Docker | The seed for a new world.
-| TMOD_USECONFIGFILE | No | If you wish to use a config file  to specify MOTD, Password, Max Players, World Name, World Size, World Seed, and a few other additional settings, set this to "Yes".
+| TMOD_DIFFICULTY | 1 | When generating a new world (and only when generating a new world), this variable will set the difficulty of the world. 1 = Normal, 2 = Master, 3 = Journey.
+| TMOD_SECURE | 0 | Adds additional cheat protection.
+| TMOD_LANGUAGE | en-US | Sets the language for the server. Available options are: `en-US` (English), `de-DE` (German), `it-IT` (Italian), `fr-FR` (French), `es-ES` (Spanish), `ru-RU` (Russian), `zh-Hans` (Chinese), `pt-BR` (Portuguese), `pl-PL` (Polish).
+| TMOD_NPCSTREAM | 60 | Reduces enemy skipping, but increases bandwidth usage. The lower the number, the less skipping will happeb, but more data is sent. 0 is off.
+| TMOD_UPNP | 0 | Automatically forwards ports with uPNP (untested, and may not work in all cases depending on network configuration)
+
+The following are environment variables which control Journey Mode settings. For all of these settings, 
+* 0 = Locked for everyone 
+* 1 = Only Changeable by Host
+* 2 = Can be changed by everyone. 
+
+Refer to the [Terraria Server Wiki](https://terraria.fandom.com/wiki/Server) for more information. The default setting for all of these is 0 when not explicitly set.
+
+* TMOD_JOURNEY_SETFROZEN
+* TMOD_JOURNEY_SETDAWN
+* TMOD_JOURNEY_SETNOON
+* TMOD_JOURNEY_SETDUSK
+* TMOD_JOURNEY_SETMIDNIGHT
+* TMOD_JOURNEY_GODMODE
+* TMOD_JOURNEY_WIND_STRENGTH
+* TMOD_JOURNEY_RAIN_STRENGTH
+* TMOD_JOURNEY_TIME_SPEED
+* TMOD_JOURNEY_RAIN_FROZEN
+* TMOD_JOURNEY_WIND_FROZEN
+* TMOD_JOURNEY_PLACEMENT_RANGE
+* TMOD_JOURNEY_SET_DIFFICULTY
+* TMOD_JOURNEY_BIOME_SPREAD
+* TMOD_JOURNEY_SPAWN_RATE
 
 # Running the Container
 
@@ -146,7 +200,6 @@ docker pull jacobsmile/tmodloader1.4:latest
 docker run -p 7777:7777 --name tmodloader --rm \
   -v $TMOD_WORLDS:/root/.local/share/Terraria/tModLoader/Worlds \
   -v $TMOD_WORKSHOP:/root/terraria-server/workshop-mods \
-  -v $TMOD_CONFIGFILE:/root/terraria-server/serverconfig.txt \
   -e TMOD_SHUTDOWN_MESSAGE='Goodbye!' \
   -e TMOD_AUTOSAVE_INTERVAL='15' \
   -e TMOD_AUTODOWNLOAD='2824688072,2824688266' \
@@ -157,7 +210,7 @@ docker run -p 7777:7777 --name tmodloader --rm \
   -e TMOD_WORLDNAME='Earth' \
   -e TMOD_WORLDSIZE='2' \
   -e TMOD_WORLDSEED='not the bees!' \
-  -e TMOD_USECONFIGFILE='No' \
+  -e TMOD_DIFFICULTY='3' \
   jacobsmile/tmodloader1.4
 ```
 

--- a/autosave.sh
+++ b/autosave.sh
@@ -2,6 +2,7 @@
 while true
 do
     sleep ${TMOD_AUTOSAVE_INTERVAL}m
+    echo -e "[SYSTEM] Saving world..."
     inject "save"
     inject "say The World has been saved."
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,16 @@ services:
       - "TMOD_MOTD=Welcome to my tModLoader Server!"
       - "TMOD_PASS=secret"
       - "TMOD_MAXPLAYERS=16"
+      # The following world settings are only used when generating a new world.
       - "TMOD_WORLDNAME=Earth"
       - "TMOD_WORLDSIZE=2"
       - "TMOD_WORLDSEED=not the bees!"
-      # If set to "Yes", it is expected to have a config.txt mapped. The Server Settings above will be ignored.
+      - "TMOD_DIFFICULTY=3"
+      # (Deprecated) If TMOD_USECONFIGFILE is set to "Yes", it is expected to have a serverconfig.txt mapped. The Server Settings above will be ignored.
       - "TMOD_USECONFIGFILE=No"
 
     volumes:
       - "/path/to/worlds/file:/root/.local/share/Terraria/tModLoader/Worlds"
       - "/path/to/workshop/folder:/root/terraria-server/workshop-mods"
-      - "/path/to/config/config.txt:/root/terraria-server/serverconfig.txt"
+      # Uncomment the below line if you plan to use a mapped config file. 
+      # - "/path/to/config/config.txt:/root/terraria-server/serverconfig.txt"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,19 @@ echo -e "[SYSTEM] Shutdown Message set to: $TMOD_SHUTDOWN_MESSAGE"
 echo -e "[SYSTEM] Save Interval set to: $TMOD_AUTOSAVE_INTERVAL minutes"
 
 configPath=/root/terraria-server/serverconfig.txt
-./prepare-config.sh
+
+# Check Config
+if [[ "$TMOD_USECONFIGFILE" == "Yes" ]]; then
+    if [ -e /root/terraria-server/customconfig.txt ]; then
+        echo -e "[!!] The tModLoader server was set to load with a config file. It will be used instead of the environment variables."
+    else
+        echo -e "[!!] FATAL: The tModLoader server was set to launch with a config file, but it was not found. Please map the file to /root/terraria-server/customconfig.txt and launch the server again."
+        sleep 5s
+        exit 1
+    fi
+else
+  ./prepare-config.sh
+fi
 
 # Trapped Shutdown, to cleanly shutdown
 function shutdown () {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,26 +1,11 @@
 #!/bin/bash
 pipe=/tmp/tmod.pipe
 
-# Check Config
-if [[ "$TMOD_USECONFIGFILE" == "Yes" ]]; then
-  if [ -e /root/terraria-server/serverconfig.txt ]; then
-    echo -e "tModLoader server will launch with the supplied config file."
-  else
-    echo -e "[!!] ERROR: The tModLoader server was set to launch with a config file, but it was not found. Please map the file and launch the server again."
-    sleep 5s
-    exit 1
-  fi
-else
-# Print Env variables
-  echo -e "Shutdown Message set to: $TMOD_SHUTDOWN_MESSAGE"
-  echo -e "Save Interval set to: $TMOD_AUTOSAVE_INTERVAL minutes"
-  echo -e "World Name set to: $TMOD_WORLDNAME"
-  echo -e "World Size set to: $TMOD_WORLDSIZE"
-  echo -e "World Seed set to: $TMOD_WORLDSEED"
-  echo -e "Max Players set to: $TMOD_MAXPLAYERS"
-  echo -e "Server Password set to: $TMOD_PASS"
-  echo -e "MOTD Set to: $TMOD_MOTD"
-fi
+echo -e "[SYSTEM] Shutdown Message set to: $TMOD_SHUTDOWN_MESSAGE"
+echo -e "[SYSTEM] Save Interval set to: $TMOD_AUTOSAVE_INTERVAL minutes"
+
+configPath=/root/terraria-server/serverconfig.txt
+./prepare-config.sh
 
 # Trapped Shutdown, to cleanly shutdown
 function shutdown () {
@@ -37,15 +22,14 @@ function shutdown () {
 
 # Download Mods
 if test -z "${TMOD_AUTODOWNLOAD}" ; then
-    echo -e ""
-    echo -e " [*] No mods to download. If you wish to download mods at runtime, please set the TMOD_AUTODOWNLOAD environment variable equal to a comma separated list of Mod Workshop IDs."
-    echo -e "For  more information, please see the Github README.\n\n"
+    echo -e "[SYSTEM] No mods to download. If you wish to download mods at runtime, please set the TMOD_AUTODOWNLOAD environment variable equal to a comma separated list of Mod Workshop IDs."
+    echo -e "[SYSTEM] For more information, please see the Github README."
     sleep 5s
 else
-    echo -e " [*] Downloading Mods specified in the TMOD_AUTODOWNLOAD Environment Variable. This may hand a while depending on the number of mods..."
+    echo -e "[SYSTEM] Downloading Mods specified in the TMOD_AUTODOWNLOAD Environment Variable. This may hand a while depending on the number of mods..."
     # Convert the Comma Separated list of Mod IDs to a list of SteamCMD commands and call SteamCMD to download them all.
     /root/terraria-server/steamcmd.sh +force_install_dir /root/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 `echo -e $TMOD_AUTODOWNLOAD | sed 's/,/ +workshop_download_item 1281930 /g'` +quit
-    echo -e " [*] Finished downloading mods.\n\n"
+    echo -e "\n[SYSTEM] Finished downloading mods."
 fi
 
 # Enable Mods
@@ -54,21 +38,19 @@ modpath=/root/terraria-server/workshop-mods/steamapps/workshop/content/1281930
 rm -f $enabledpath
 
 if test -z "${TMOD_ENABLEDMODS}" ; then
-    echo -e ""
-    echo -e " [*] No mods to load. Please set the TMOD_ENABLEDMODS environment variable equal to a comma separated list of Mod Workshop IDs."
-    echo -e " For  more information, please see the Github README.\n\n"
+    echo -e "[SYSTEM] No mods to load. Please set the TMOD_ENABLEDMODS environment variable equal to a comma separated list of Mod Workshop IDs."
+    echo -e "[SYSTEM] For more information, please see the Github README."
     sleep 5s
 else
-  echo -e " [*] Enabling Mods specified in the TMOD_ENABLEDMODS Environment variable..."
+  echo -e "[SYSTEM] Enabling Mods specified in the TMOD_ENABLEDMODS Environment variable..."
   echo '[' >> $enabledpath
   # Convert the Comma separated list of Mod IDs to an iterable list. We use this to drill through the directories and get the internal names of the mods.
   echo -e $TMOD_ENABLEDMODS | tr "," "\n" | while read LINE
   do
-    echo -e ""
-    echo -e " [*] Enabling $LINE..."
+    echo -e "[SYSTEM] Enabling $LINE..."
 
     if [ $? -ne 0 ]; then
-      echo -e " [!!] Mod ID $LINE not found! Has it been downloaded?"
+      echo -e "[!!] Mod ID $LINE not found! Has it been downloaded?"
       continue
     fi
     modname=$(ls -1 $(ls -d $modpath/$LINE/*/|tail -n 1) | sed -e 's/\.tmod$//')
@@ -78,41 +60,14 @@ else
     fi
     # For each mod name that we resolve, write the internal name of it to the enabled.json file.
     echo "\"$modname\"," >> $enabledpath
-    echo -e " [*] Enabled $modname ($LINE) "
+    echo -e "[SYSTEM] Enabled $modname ($LINE) "
   done
     echo ']' >> $enabledpath
-    echo " [*] Finished loading mods."
+    echo "\n[SYSTEM] Finished loading mods."
 fi
 
-# Base startup command
-server="/root/terraria-server/LaunchUtils/ScriptCaller.sh -server -steamworkshopfolder \"/root/terraria-server/workshop-mods/steamapps/workshop\""
-
-# If config, we supply it at the command line.
-if [[ "$TMOD_USECONFIGFILE" == "Yes" ]]; then
-  server="$server -config /root/terraria-server/serverconfig.txt"
-
-else
-  # Check if the world file exists.
-  if [ -e "/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" ]; then
-    server="$server -world \"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\""
-  else
-  # If it does not, alert the player, and set the startup parameters to automatically generate the world.
-    echo -e "[!!] WARNING: The world \"$TMOD_WORLDNAME\" was not found. The server will automatically create a new world."
-    sleep 3s
-    server="$server -world \"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\""
-    server="$server -autocreate $TMOD_WORLDSIZE -worldname \"$TMOD_WORLDNAME\" -seed \"$TMOD_WORLDSEED\""
-  fi
-
-  server="$server -players $TMOD_MAXPLAYERS"
-
-  if [[ "$TMOD_PASS" == "N/A" ]]; then
-    echo -e "[!!] Server Password has been disabled."
-  else
-    server="$server -pass \"$TMOD_PASS\""
-  fi
-
-  server="$server -motd \"$TMOD_MOTD\""
-fi
+# Startup command
+server="/root/terraria-server/LaunchUtils/ScriptCaller.sh -server -steamworkshopfolder \"/root/terraria-server/workshop-mods/steamapps/workshop\" -config \"$configPath\""
 
 # Trap the shutdown
 trap shutdown TERM INT

--- a/inject.sh
+++ b/inject.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+# This file will send input from the docker exec to the console.
 
 tmux send-keys "$1" Enter

--- a/prepare-config.sh
+++ b/prepare-config.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Print Env variables
+
 configPath=/root/terraria-server/serverconfig.txt
 echo -e "[COFNIG] Config File Path: $configPath"
 echo -e "[CONFIG] Setting Config Values..."

--- a/prepare-config.sh
+++ b/prepare-config.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Print Env variables
+configPath=/root/terraria-server/serverconfig.txt
+echo -e "[COFNIG] Config File Path: $configPath"
+echo -e "[CONFIG] Setting Config Values..."
+
+echo -e "[CONFIG] TERRARIA CONFIG SETTINGS"
+echo -e "[CONFIG] MOTD Set to: $TMOD_MOTD"
+echo -e "[CONFIG] Server Password set to: $TMOD_PASS"
+echo -e "[CONFIG] Max Players set to: $TMOD_MAXPLAYERS"
+echo -e "[CONFIG] World Name set to: $TMOD_WORLDNAME"
+echo -e "[CONFIG] World Size set to: $TMOD_WORLDSIZE"
+echo -e "[CONFIG] World Seed set to: $TMOD_WORLDSEED"
+echo -e "[CONFIG] Difficulty set to: $TMOD_DIFFICULTY"
+echo -e "[CONFIG] Secure Mode set to: $TMOD_SECURE"
+echo -e "[CONFIG] Language set to: $TMOD_LANGUAGE"
+echo -e "[CONFIG] NPC Stream set to: $TMOD_NPCSTREAM"
+echo -e "[CONFIG] UPNP set to: $TMOD_UPNP"
+echo -e "[CONFIG] Priority set to: $TMOD_PRIORITY"
+echo -e "[CONFIG] JOURNEY MODE SETTINGS"
+echo -e "[CONFIG] journeypermission_time_setfrozen: $TMOD_JOURNEY_SETFROZEN"
+echo -e "[CONFIG] journeypermission_time_setdawn: $TMOD_JOURNEY_SETDAWN"
+echo -e "[CONFIG] journeypermission_time_setnoon: $TMOD_JOURNEY_SETNOON"
+echo -e "[CONFIG] journeypermission_time_setdusk: $TMOD_JOURNEY_SETDUSK"
+echo -e "[CONFIG] journeypermission_time_setmidnight: $TMOD_JOURNEY_SETMIDNIGHT"
+echo -e "[CONFIG] journeypermission_godmode: $TMOD_JOURNEY_GODMODE"
+echo -e "[CONFIG] journeypermission_wind_setstrength: $TMOD_JOURNEY_WIND_STRENGTH"
+echo -e "[CONFIG] journeypermission_rain_setstrength: $TMOD_JOURNEY_RAIN_STRENGTH"
+echo -e "[CONFIG] journeypermission_time_setspeed: $TMOD_JOURNEY_TIME_SPEED"
+echo -e "[CONFIG] journeypermission_rain_setfrozen: $TMOD_JOURNEY_RAIN_FROZEN"
+echo -e "[CONFIG] journeypermission_wind_setfrozen: $TMOD_JOURNEY_WIND_FROZEN"
+echo -e "[CONFIG] journeypermission_increaseplacementrange: $TMOD_JOURNEY_PLACEMENT_RANGE"
+echo -e "[CONFIG] journeypermission_setdifficulty: $TMOD_JOURNEY_SET_DIFFICULTY"
+echo -e "[CONFIG] journeypermission_biomespread_setfrozen: $TMOD_JOURNEY_BIOME_SPREAD"
+echo -e "[CONFIG] journeypermission_setspawnrate: $TMOD_JOURNEY_SPAWN_RATE"
+
+# Check if the world file exists.
+if [ -e "/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" ]; then
+    echo "world=\"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\"" >> "$configPath"
+else
+# If it does not, alert the player, and set the startup parameters to automatically generate the world.
+    echo -e "[!!] WARNING: The world \"$TMOD_WORLDNAME\" was not found. The server will automatically create a new world."
+    sleep 3s
+    echo "world=\"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\"" >> "$configPath"
+    echo "worldname=$TMOD_WORLDNAME" >> "$configPath"
+    echo "autocreate=$TMOD_WORLDSIZE" >> "$configPath"
+fi
+
+if [[ "$TMOD_PASS" == "N/A" ]]; then
+    echo -e "[!!] Server Password has been disabled."
+else
+    echo "password=$TMOD_PASS" >> "$configPath"
+fi
+
+echo "motd=$TMOD_MOTD" >> "$configPath"
+echo "maxplayers=$TMOD_MAXPLAYERS" >> "$configPath"
+echo "seed=$TMOD_WORLDSEED" >> "$configPath"
+echo "difficulty=$TMOD_DIFFICULTY" >> "$configPath"
+echo "secure=$TMOD_SECURE" >> "$configPath"
+echo "language=$TMOD_LANGUAGE" >> "$configPath"
+echo "npcstream=$TMOD_NPCSTREAM" >> "$configPath"
+echo "upnp=$TMOD_UPNP" >> "$configPath"
+echo "priority=$TMOD_PRIORITY" >> "$configPath"
+
+echo "journeypermission_time_setfrozen=$TMOD_JOURNEY_SETFROZEN" >> "$configPath"
+echo "journeypermission_time_setdawn=$TMOD_JOURNEY_SETDAWN" >> "$configPath"
+echo "journeypermission_time_setnoon=$TMOD_JOURNEY_SETNOON" >> "$configPath"
+echo "journeypermission_time_setdusk=$TMOD_JOURNEY_SETDUSK" >> "$configPath"
+echo "journeypermission_time_setmidnight=$TMOD_JOURNEY_SETMIDNIGHT" >> "$configPath"
+echo "journeypermission_godmode=$TMOD_JOURNEY_GODMODE" >> "$configPath"
+echo "journeypermission_wind_setstrength=$TMOD_JOURNEY_WIND_STRENGTH" >> "$configPath"
+echo "journeypermission_rain_setstrength=$TMOD_JOURNEY_RAIN_STRENGTH" >> "$configPath"
+echo "journeypermission_time_setspeed=$TMOD_JOURNEY_TIME_SPEED" >> "$configPath"
+echo "journeypermission_rain_setfrozen=$TMOD_JOURNEY_RAIN_FROZEN" >> "$configPath"
+echo "journeypermission_wind_setfrozen=$TMOD_JOURNEY_WIND_FROZEN" >> "$configPath"
+echo "journeypermission_increaseplacementrange=$TMOD_JOURNEY_PLACEMENT_RANGE" >> "$configPath"
+echo "journeypermission_setdifficulty=$TMOD_JOURNEY_SET_DIFFICULTY" >> "$configPath"
+echo "journeypermission_biomespread_setfrozen=$TMOD_JOURNEY_BIOME_SPREAD" >> "$configPath"
+echo "journeypermission_setspawnrate=$TMOD_JOURNEY_SPAWN_RATE" >> "$configPath"
+
+echo -e "[CONFIG] Finished setting config settings."


### PR DESCRIPTION
This rewrite of the config handling system enables additional settings, including Difficulty (#11), and Journey Mode settings. There now are environment variables which control all of the Terraria Server configuration settings, and thus, the use of a custom config file has been deprecated.

Additionally, this update attempts to fix #10, which I believe occurred with line endings being CRLF, not LF. From my testing, this does not happen anymore. 