### PR TITLE
Removing quotation marks in file paths

### DIFF
--- a/prepare-config.sh
+++ b/prepare-config.sh
@@ -38,12 +38,14 @@ echo -e "[CONFIG] journeypermission_setspawnrate: $TMOD_JOURNEY_SPAWN_RATE"
 
 # Check if the world file exists.
 if [ -e "/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" ]; then
-    echo "world=\"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\"" >> "$configPath"
+    echo "world=/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
+    echo "worldpath=/root/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
 else
 # If it does not, alert the player, and set the startup parameters to automatically generate the world.
     echo -e "[!!] WARNING: The world \"$TMOD_WORLDNAME\" was not found. The server will automatically create a new world."
     sleep 3s
-    echo "world=\"/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld\"" >> "$configPath"
+    echo "world=/root/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
+    echo "worldpath=/root/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
     echo "worldname=$TMOD_WORLDNAME" >> "$configPath"
     echo "autocreate=$TMOD_WORLDSIZE" >> "$configPath"
 fi


### PR DESCRIPTION
Fixes #15 

Apparently the Terraria Server cannot handle quotation marks around a file path for some reason, it reads it as a literal and ultimately creates a directory named a quotation mark. I didn't even know this was possible. 