### PR TITLE
Updates to the directory structure, and other small additional tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,3 +139,4 @@ RUN ./LaunchUtils/DotNetInstall.sh
 
 ENTRYPOINT ["./entrypoint.sh"]
 
+VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ WORKDIR $HOME
 
 RUN steamcmd $HOME +login anonymous +quit
 
-RUN wget https://github.com/tModLoader/tModLoader/releases/download/${TMOD_VERSION}/tModLoader.zip 
+RUN [ $TMOD_VERSION = "latest" ] && wget https://github.com/tModLoader/tModLoader/releases/latest/download/tModLoader.zip || wget https://github.com/tModLoader/tModLoader/releases/download/${TMOD_VERSION}/tModLoader.zip
 RUN unzip -o tModLoader.zip \
     && rm tModLoader.zip
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,9 @@ mkdir $WORLDSPATH
 mkdir $MODSPATH
 tModLoader_ID=1281930
 internalModsPathPrefix=$HOME/mods
-internalModsFullPath=$internalModsPathPrefix/steamapps/workshop/content/
-mkdir -p $internalModsFullPath
-ln -s -T $MODSPATH $internalModsFullPath/$tModLoader_ID
+internalModsFullPath=$internalModsPathPrefix/steamapps/workshop
+mkdir -p $internalModsFullPath/content
+ln -s -T $MODSPATH $internalModsFullPath/content/$tModLoader_ID
 
 if [[ "$UPDATE_NOTICE" != "false" ]]; then
   echo -e "\n\n!!-------------------------------------------------------------------!!"
@@ -87,7 +87,7 @@ else
       echo -e "[!!] Mod ID $LINE not found! Has it been downloaded?"
       continue
     fi
-    modname=$(ls -1 $(ls -d $internalModsFullPath/$tModLoader_ID/$LINE/*/|tail -n 1) | sed -e 's/\.tmod$//')
+    modname=$(ls -1 $(ls -d $internalModsFullPath/content/$tModLoader_ID/$LINE/*/|tail -n 1) | sed -e 's/\.tmod$//')
     if [ $? -ne 0 ]; then
       echo -e " [!!] An error occurred while attempting to load $LINE."
       continue
@@ -97,9 +97,11 @@ else
     echo -e "[SYSTEM] Enabled $modname ($LINE) "
   done
     echo ']' >> $enabledpath
-    echo ']' >> $enabledpath
     echo "\n[SYSTEM] Finished loading mods."
 fi
+
+mkdir -p $HOME/.local/share/Terraria/tModLoader/Mods
+ln -s $enabledpath $HOME/.local/share/Terraria/tModLoader/Mods/enabled.json
 
 # Startup command
 server="$HOME/LaunchUtils/ScriptCaller.sh -server -steamworkshopfolder \"$internalModsFullPath\" -config \"$CONFIGPATH\""

--- a/prepare-config.sh
+++ b/prepare-config.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
+CONFIGPATH=$DATAPATH/server_config.txt
+
 # Print Env variables
-
-configPath=$HOME/terraria-server/serverconfig.txt
-echo -e "[COFNIG] Config File Path: $configPath"
+echo -e "[COFNIG] Config File Path: $CONFIGPATH"
 echo -e "[CONFIG] Setting Config Values..."
-
 echo -e "[CONFIG] TERRARIA CONFIG SETTINGS"
 echo -e "[CONFIG] MOTD Set to: $TMOD_MOTD"
 echo -e "[CONFIG] Server Password set to: $TMOD_PASS"
@@ -37,49 +36,49 @@ echo -e "[CONFIG] journeypermission_biomespread_setfrozen: $TMOD_JOURNEY_BIOME_S
 echo -e "[CONFIG] journeypermission_setspawnrate: $TMOD_JOURNEY_SPAWN_RATE"
 
 # Check if the world file exists.
-if [ -e "$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" ]; then
-    echo "world=$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
-    echo "worldpath=$HOME/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
+if [ -e "$WORLDSPATH/$TMOD_WORLDNAME.wld" ]; then
+    echo "world=$WORLDSPATH/$TMOD_WORLDNAME.wld" >> "$CONFIGPATH"
+    echo "worldpath=$WORLDSPATH" >> "$CONFIGPATH"
 else
 # If it does not, alert the player, and set the startup parameters to automatically generate the world.
     echo -e "[!!] WARNING: The world \"$TMOD_WORLDNAME\" was not found. The server will automatically create a new world."
     sleep 3s
-    echo "world=$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
-    echo "worldpath=$HOME/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
-    echo "worldname=$TMOD_WORLDNAME" >> "$configPath"
-    echo "autocreate=$TMOD_WORLDSIZE" >> "$configPath"
+    echo "world=$WORLDSPATH/$TMOD_WORLDNAME.wld" >> "$CONFIGPATH"
+    echo "worldpath=$WORLDSPATH" >> "$CONFIGPATH"
+    echo "worldname=$TMOD_WORLDNAME" >> "$CONFIGPATH"
+    echo "autocreate=$TMOD_WORLDSIZE" >> "$CONFIGPATH"
 fi
 
 if [[ "$TMOD_PASS" == "N/A" ]]; then
     echo -e "[!!] Server Password has been disabled."
 else
-    echo "password=$TMOD_PASS" >> "$configPath"
+    echo "password=$TMOD_PASS" >> "$CONFIGPATH"
 fi
 
-echo "motd=$TMOD_MOTD" >> "$configPath"
-echo "maxplayers=$TMOD_MAXPLAYERS" >> "$configPath"
-echo "seed=$TMOD_WORLDSEED" >> "$configPath"
-echo "difficulty=$TMOD_DIFFICULTY" >> "$configPath"
-echo "secure=$TMOD_SECURE" >> "$configPath"
-echo "language=$TMOD_LANGUAGE" >> "$configPath"
-echo "npcstream=$TMOD_NPCSTREAM" >> "$configPath"
-echo "upnp=$TMOD_UPNP" >> "$configPath"
-echo "priority=$TMOD_PRIORITY" >> "$configPath"
+echo "motd=$TMOD_MOTD" >> "$CONFIGPATH"
+echo "maxplayers=$TMOD_MAXPLAYERS" >> "$CONFIGPATH"
+echo "seed=$TMOD_WORLDSEED" >> "$CONFIGPATH"
+echo "difficulty=$TMOD_DIFFICULTY" >> "$CONFIGPATH"
+echo "secure=$TMOD_SECURE" >> "$CONFIGPATH"
+echo "language=$TMOD_LANGUAGE" >> "$CONFIGPATH"
+echo "npcstream=$TMOD_NPCSTREAM" >> "$CONFIGPATH"
+echo "upnp=$TMOD_UPNP" >> "$CONFIGPATH"
+echo "priority=$TMOD_PRIORITY" >> "$CONFIGPATH"
 
-echo "journeypermission_time_setfrozen=$TMOD_JOURNEY_SETFROZEN" >> "$configPath"
-echo "journeypermission_time_setdawn=$TMOD_JOURNEY_SETDAWN" >> "$configPath"
-echo "journeypermission_time_setnoon=$TMOD_JOURNEY_SETNOON" >> "$configPath"
-echo "journeypermission_time_setdusk=$TMOD_JOURNEY_SETDUSK" >> "$configPath"
-echo "journeypermission_time_setmidnight=$TMOD_JOURNEY_SETMIDNIGHT" >> "$configPath"
-echo "journeypermission_godmode=$TMOD_JOURNEY_GODMODE" >> "$configPath"
-echo "journeypermission_wind_setstrength=$TMOD_JOURNEY_WIND_STRENGTH" >> "$configPath"
-echo "journeypermission_rain_setstrength=$TMOD_JOURNEY_RAIN_STRENGTH" >> "$configPath"
-echo "journeypermission_time_setspeed=$TMOD_JOURNEY_TIME_SPEED" >> "$configPath"
-echo "journeypermission_rain_setfrozen=$TMOD_JOURNEY_RAIN_FROZEN" >> "$configPath"
-echo "journeypermission_wind_setfrozen=$TMOD_JOURNEY_WIND_FROZEN" >> "$configPath"
-echo "journeypermission_increaseplacementrange=$TMOD_JOURNEY_PLACEMENT_RANGE" >> "$configPath"
-echo "journeypermission_setdifficulty=$TMOD_JOURNEY_SET_DIFFICULTY" >> "$configPath"
-echo "journeypermission_biomespread_setfrozen=$TMOD_JOURNEY_BIOME_SPREAD" >> "$configPath"
-echo "journeypermission_setspawnrate=$TMOD_JOURNEY_SPAWN_RATE" >> "$configPath"
+echo "journeypermission_time_setfrozen=$TMOD_JOURNEY_SETFROZEN" >> "$CONFIGPATH"
+echo "journeypermission_time_setdawn=$TMOD_JOURNEY_SETDAWN" >> "$CONFIGPATH"
+echo "journeypermission_time_setnoon=$TMOD_JOURNEY_SETNOON" >> "$CONFIGPATH"
+echo "journeypermission_time_setdusk=$TMOD_JOURNEY_SETDUSK" >> "$CONFIGPATH"
+echo "journeypermission_time_setmidnight=$TMOD_JOURNEY_SETMIDNIGHT" >> "$CONFIGPATH"
+echo "journeypermission_godmode=$TMOD_JOURNEY_GODMODE" >> "$CONFIGPATH"
+echo "journeypermission_wind_setstrength=$TMOD_JOURNEY_WIND_STRENGTH" >> "$CONFIGPATH"
+echo "journeypermission_rain_setstrength=$TMOD_JOURNEY_RAIN_STRENGTH" >> "$CONFIGPATH"
+echo "journeypermission_time_setspeed=$TMOD_JOURNEY_TIME_SPEED" >> "$CONFIGPATH"
+echo "journeypermission_rain_setfrozen=$TMOD_JOURNEY_RAIN_FROZEN" >> "$CONFIGPATH"
+echo "journeypermission_wind_setfrozen=$TMOD_JOURNEY_WIND_FROZEN" >> "$CONFIGPATH"
+echo "journeypermission_increaseplacementrange=$TMOD_JOURNEY_PLACEMENT_RANGE" >> "$CONFIGPATH"
+echo "journeypermission_setdifficulty=$TMOD_JOURNEY_SET_DIFFICULTY" >> "$CONFIGPATH"
+echo "journeypermission_biomespread_setfrozen=$TMOD_JOURNEY_BIOME_SPREAD" >> "$CONFIGPATH"
+echo "journeypermission_setspawnrate=$TMOD_JOURNEY_SPAWN_RATE" >> "$CONFIGPATH"
 
 echo -e "[CONFIG] Finished setting config settings."


### PR DESCRIPTION
* ~~Removed the builder step by building directly on Steam's Ubuntu image, leading in a smaller final container (efficiency score 95% according to [dive](https://github.com/wagoodman/dive)~~ Actually added the builder back, but after reorganising and cleaning up some stuff, image is now only 718 Mb with 99% efficiency.
* Removed the need to reacquire root during the build by directly setting the correct permissions via `--chown` and `--chmod` flags in the Dockerfile
* Added support for build arg `TMOD_VERSION=latest` so it automatically grabs the latest available release
* Reworked the directory structure like so:
    1. * The server itself lives in /terraria-server
    2. * Worlds, Mods, server_config.txt and enabled_mods.json all live in /data
This means users can now bind mount one folder on the host to /data and they'll find everything in there, which is useful for persistance across restarts.

NOTE: As per the recommended approach, users **must** chown the host folder to 456:456 before starting the container, otherwise the container might not be able to write its stuff in it.

Example:
```
chown -R 456:456 /path/on/the/host/terraria
docker run -v /path/on/the/host/terraria:/data 
```