### PR TITLE
Overly Sensitive Permissions Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,19 +117,16 @@ RUN chown -R root:root /usr/bin/ /etc/ssl/certs /lib/ /usr/lib/
 RUN apt-get update \
     && apt-get install -y wget unzip tmux bash libsdl2-2.0-0
 
-# Create a user and drop root
-RUN useradd -ms /bin/bash terraria
-ENV HOME=/home/terraria
-USER terraria
+RUN mkdir /data
+RUN mkdir /data/worlds
+RUN mkdir /data/mods
 
 EXPOSE 7777
 
-WORKDIR $HOME/terraria-server
+WORKDIR /terraria-server
 
-RUN steamcmd $HOME/terraria-server +login anonymous +quit
+RUN steamcmd /terraria-server +login anonymous +quit
 
-# Acquire root once more just to set the correct permissions and download
-USER root
 RUN wget https://github.com/tModLoader/tModLoader/releases/download/${TMOD_VERSION}/tModLoader.zip 
 RUN unzip -o tModLoader.zip \
     && rm tModLoader.zip
@@ -140,16 +137,8 @@ COPY inject.sh /usr/local/bin/inject
 COPY autosave.sh .
 COPY prepare-config.sh .
 
-RUN chown -R terraria:terraria /home/terraria \
-    && chmod 755 ./LaunchUtils/DotNetInstall.sh \
-    && chmod 755 ./start-tModLoaderServer.sh \
-    && chmod 755 ./LaunchUtils/ScriptCaller.sh \
-    && chmod 755 ./entrypoint.sh \
-    && chmod 755 /usr/local/bin/inject \
-    && chmod 755 ./autosave.sh \
-    && chmod 755 ./prepare-config.sh \
-    && chmod -R 755 /home/terraria
-USER terraria
+RUN chmod +x ./LaunchUtils/ScriptCaller.sh
+RUN chmod +x ./LaunchUtils/DotNetInstall.sh
 
 RUN ./LaunchUtils/DotNetInstall.sh
 RUN mkdir -p $HOME/.local/share/Terraria/tModLoader/Worlds \

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # This Copyright does NOT include that which is owned by Re-Logic, or the TML Team and only includes that which is contained in the Dockerfile and assorted scripts, not counting the DotNetInstall script..
 
-Copyright 2022 JACOBSMILE
+Copyright 2023 JACOBSMILE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tModLoader Powered By Docker
-![Discord](https://img.shields.io/discord/1132368789518950521?logo=discord&label=Discord%20Server&style=for-the-badge)
+[![Discord](https://img.shields.io/discord/1132368789518950521?logo=discord&label=Discord%20Server&style=for-the-badge)](https://discord.gg/dHnVYYGed7)
 
 ![Auto-Update Badge](https://img.shields.io/github/actions/workflow/status/jacobsmile/tmodloader1.4/tmodloader-check.yml?logo=github&label=tModLoader%20Auto-Updater&style=for-the-badge)
 
@@ -8,8 +8,8 @@
 ![OpenIssues](https://img.shields.io/github/issues/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge)
 ![ClosedIssues](https://img.shields.io/github/issues-closed/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge)
 
-![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)
-![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)
+[![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)](https://registry.hub.docker.com/r/jacobsmile/tmodloader1.4)
+[![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)](](https://registry.hub.docker.com/r/jacobsmile/tmodloader1.4))
 
 ![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge)
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
 # tModLoader Powered By Docker
-![Auto-Update Badge](https://img.shields.io/github/actions/workflow/status/jacobsmile/tmodloader1.4/tmodloader-check.yml?logo=github&label=tModLoader%20Auto-Updater&style=for-the-badge
-)
+![Discord](https://img.shields.io/discord/1132368789518950521?logo=discord&label=Discord%20Server&style=for-the-badge)
 
-![Contributors](https://img.shields.io/github/contributors/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
-)
-![Stars](https://img.shields.io/github/stars/jacobsmile/tmodloader1.4?logo=github&label=github%20stars&style=for-the-badge
-)
-![OpenIssues](https://img.shields.io/github/issues/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
-)
-![ClosedIssues](https://img.shields.io/github/issues-closed/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
-)
+![Auto-Update Badge](https://img.shields.io/github/actions/workflow/status/jacobsmile/tmodloader1.4/tmodloader-check.yml?logo=github&label=tModLoader%20Auto-Updater&style=for-the-badge)
 
-![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge
-)
-![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge
-)
+![Contributors](https://img.shields.io/github/contributors/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge)
+![Stars](https://img.shields.io/github/stars/jacobsmile/tmodloader1.4?logo=github&label=github%20stars&style=for-the-badge)
+![OpenIssues](https://img.shields.io/github/issues/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge)
+![ClosedIssues](https://img.shields.io/github/issues-closed/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge)
 
-![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge
-)
+![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)
+![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)
+
+![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge)
 
 ---
 # Important Notices

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge
 )
 
-![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-Click%20to%20view!-orange?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge
+![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge
 )
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # tModLoader Powered By Docker
-![Auto-Update Badge](https://github.com/JACOBSMILE/tmodloader1.4/actions/workflows/tmodloader-check.yml/badge.svg)
+![Auto-Update Badge](https://img.shields.io/github/actions/workflow/status/jacobsmile/tmodloader1.4/tmodloader-check.yml?logo=github&label=tModLoader%20Auto-Updater&style=for-the-badge
+)
+
+![Contributors](https://img.shields.io/github/contributors/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
+)
+![Stars](https://img.shields.io/github/stars/jacobsmile/tmodloader1.4?logo=github&label=github%20stars&style=for-the-badge
+)
+![OpenIssues](https://img.shields.io/github/issues/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
+)
+![ClosedIssues](https://img.shields.io/github/issues-closed/jacobsmile/tmodloader1.4?logo=github&style=for-the-badge
+)
+
+![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge
+)
+![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge
+)
+
+![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-Click%20to%20view!-orange?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge
+)
 
 ---
 # Important Notices

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![DockerPulls](https://img.shields.io/docker/pulls/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)](https://registry.hub.docker.com/r/jacobsmile/tmodloader1.4)
 [![DockerStars](https://img.shields.io/docker/stars/jacobsmile/tmodloader1.4?logo=docker&style=for-the-badge)](](https://registry.hub.docker.com/r/jacobsmile/tmodloader1.4))
 
-![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge)
+[![Unraid](https://img.shields.io/badge/Available_On_Unraid_Community_Apps!-gray?logo=unraid&link=https%3A%2F%2Funraid.net%2Fcommunity%2Fapps%3Fq%3Dtmodloader%23r&style=for-the-badge)](https://unraid.net/community/apps?q=tmodloader#r)
 
 ---
 # Important Notices

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 ![Auto-Update Badge](https://github.com/JACOBSMILE/tmodloader1.4/actions/workflows/tmodloader-check.yml/badge.svg)
 
 ---
-# Important Notice
+# Important Notices
+
+## Recent changes to Directory Mapping
+This container recently updated from requiring separate mapped `world` and `mods` directories to your host for persistence. This has been updated to a common `/data` directory. This README has been updated to reflect this change.
+
+## Upcoming 1.4.4 Update
 tModLoader will soon be updating to Terraria version 1.4.4. It is very likely that this update will cause breaking changes to this Docker container. Upon release of 1.4.4, this container's functionality will be reviewed. Relevant issues and fixes will be tracked in the Github Repository. Working 1.4.4 and 1.4.3 tags will be listed during the transition in the README.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     image: 'jacobsmile/tmodloader1.4:latest'
     container_name: 'tmodloader'
     pull_policy: always
-    user: terraria:terraria
-    working_dir: /home/terraria/terraria-server
+    working_dir: /terraria-server
     ports:
       - "7777:7777"
     expose:
@@ -32,8 +31,7 @@ services:
       - "UPDATE_NOTICE=false"
 
     volumes:
-    #### UPDATE THE BELOW PATHS TO A DIRECTORY LOCAL TO YOUR MACHINE #####
-      - "path/to/worlds/folder:/home/terraria/.local/share/Terraria/tModLoader/Worlds"
-      - "path/to/mods/folder:/home/terraria/terraria-server/workshop-mods"
+    #### By default, the below setting will create a data directory on your host where this compose file lives.
+      - "./data:/data"
       # Uncomment the below line if you plan to use a mapped config file. 
       # - "/path/to/config/config.txt:/root/terraria-server/serverconfig.txt"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 pipe=/tmp/tmod.pipe
 
+echo -e "\n[UPDATE NOTICE] Recently, this container has replaced mapping worlds and mods directories for a common /data directory. Please review the README on the GitHub for more information if your server is suddenly not loading your previous world files."
+echo -e "\n[1.4.4 NOTICE] tModLoader will soon be updating to version 1.4.4. This will likely be a breaking change to this container. Once this update releases, there will be a period of time where this container may not work. Please follow the GitHub repository for more information."
+echo -e "\n\n***The server will start in 20 seconds..."
+sleep 20s
+
 echo -e "[SYSTEM] Shutdown Message set to: $TMOD_SHUTDOWN_MESSAGE"
 echo -e "[SYSTEM] Save Interval set to: $TMOD_AUTOSAVE_INTERVAL minutes"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,31 +1,17 @@
 #!/bin/bash
 pipe=/tmp/tmod.pipe
 
-# if [[ "$UPDATE_NOTICE" != "false" ]]; then
-#   echo -e "\n\n!!-------------------------------------------------------------------!!"
-#   echo -e "REGARDING ISSUE #12"
-#   echo -e "[UPDATE NOTICE] Recently, this container has been updated to remove dependency on the Root User account inside the container."
-#   echo -e "[UPDATE NOTICE] Because of this update, prior configurations which mapped HOST directories for Mods, Worlds and Custom Configs will no longer work."
-#   echo -e "[UPDATE NOTICE] Your World files are NOT DELETED!"
-#   echo -e "[UPDATE NOTICE] If you are experiencing issues with your worlds or mods loading properly, please refer to the following SFB for more information."
-#   echo -e "[UPDATE NOTICE] https://github.com/JACOBSMILE/tmodloader1.4/wiki/SFB:-Removing-Dependency-on-Root-(Issue-12)"
-#   echo -e "!!-------------------------------------------------------------------!!"
-#   echo -e "\n[SYSTEM] The Server will launch in 30 seconds. To disable this notice, set the UPDATE_NOTICE environment variable equal to \"false\"."
-#   echo -e "[SYSTEM] This notice will be eventually removed in a later update."
-#   sleep 30s
-# fi
-
 echo -e "[SYSTEM] Shutdown Message set to: $TMOD_SHUTDOWN_MESSAGE"
 echo -e "[SYSTEM] Save Interval set to: $TMOD_AUTOSAVE_INTERVAL minutes"
 
-configPath=$HOME/terraria-server/serverconfig.txt
+configPath=/terraria-server/serverconfig.txt
 
 # Check Config
 if [[ "$TMOD_USECONFIGFILE" == "Yes" ]]; then
-    if [ -e $HOME/terraria-server/customconfig.txt ]; then
+    if [ -e /terraria-server/customconfig.txt ]; then
         echo -e "[!!] The tModLoader server was set to load with a config file. It will be used instead of the environment variables."
     else
-        echo -e "[!!] FATAL: The tModLoader server was set to launch with a config file, but it was not found. Please map the file to $HOME/terraria-server/customconfig.txt and launch the server again."
+        echo -e "[!!] FATAL: The tModLoader server was set to launch with a config file, but it was not found. Please map the file to /terraria-server/customconfig.txt and launch the server again."
         sleep 5s
         exit 1
     fi
@@ -54,13 +40,13 @@ if test -z "${TMOD_AUTODOWNLOAD}" ; then
 else
     echo -e "[SYSTEM] Downloading Mods specified in the TMOD_AUTODOWNLOAD Environment Variable. This may hand a while depending on the number of mods..."
     # Convert the Comma Separated list of Mod IDs to a list of SteamCMD commands and call SteamCMD to download them all.
-    steamcmd +force_install_dir $HOME/terraria-server/workshop-mods +login anonymous +workshop_download_item 1281930 `echo -e $TMOD_AUTODOWNLOAD | sed 's/,/ +workshop_download_item 1281930 /g'` +quit
+    steamcmd +force_install_dir /data/mods +login anonymous +workshop_download_item 1281930 `echo -e $TMOD_AUTODOWNLOAD | sed 's/,/ +workshop_download_item 1281930 /g'` +quit
     echo -e "[SYSTEM] Finished downloading mods."
 fi
 
 # Enable Mods
 enabledpath=$HOME/.local/share/Terraria/tModLoader-1.4.3/Mods/enabled.json
-modpath=$HOME/terraria-server/workshop-mods/steamapps/workshop/content/1281930
+modpath=/data/mods/steamapps/workshop/content/1281930
 rm -f $enabledpath
 mkdir -p $HOME/.local/share/Terraria/tModLoader-1.4.3/Mods
 touch $enabledpath
@@ -95,7 +81,7 @@ else
 fi
 
 # Startup command
-server="$HOME/terraria-server/LaunchUtils/ScriptCaller.sh -server -steamworkshopfolder \"$HOME/terraria-server/workshop-mods/steamapps/workshop\" -config \"$configPath\""
+server="/terraria-server/LaunchUtils/ScriptCaller.sh -server -steamworkshopfolder \"/data/mods/steamapps/workshop\" -config \"$configPath\""
 
 # Trap the shutdown
 trap shutdown TERM INT
@@ -108,7 +94,7 @@ mkfifo $pipe
 tmux new-session -d "$server | tee $pipe"
 
 # Call the autosaver
-$HOME/terraria-server/autosave.sh &
+/terraria-server/autosave.sh &
 
 # Infinitely print the contents of the pipe, so the container still logs the Terraria Server.
 cat $pipe &

--- a/prepare-config.sh
+++ b/prepare-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Print Env variables
-configPath=$HOME/terraria-server/serverconfig.txt
+configPath=/terraria-server/serverconfig.txt
 echo -e "[COFNIG] Config File Path: $configPath"
 echo -e "[CONFIG] Setting Config Values..."
 
@@ -36,15 +36,15 @@ echo -e "[CONFIG] journeypermission_biomespread_setfrozen: $TMOD_JOURNEY_BIOME_S
 echo -e "[CONFIG] journeypermission_setspawnrate: $TMOD_JOURNEY_SPAWN_RATE"
 
 # Check if the world file exists.
-if [ -e "$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" ]; then
-    echo "world=$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
-    echo "worldpath=$HOME/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
+if [ -e "/data/worlds/$TMOD_WORLDNAME.wld" ]; then
+    echo "world=/data/worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
+    echo "worldpath=/data/worlds/" >> "$configPath"
 else
 # If it does not, alert the player, and set the startup parameters to automatically generate the world.
     echo -e "[!!] WARNING: The world \"$TMOD_WORLDNAME\" was not found. The server will automatically create a new world."
     sleep 3s
-    echo "world=$HOME/.local/share/Terraria/tModLoader/Worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
-    echo "worldpath=$HOME/.local/share/Terraria/tModLoader/Worlds/" >> "$configPath"
+    echo "world=/data/worlds/$TMOD_WORLDNAME.wld" >> "$configPath"
+    echo "worldpath=/data/worlds/" >> "$configPath"
     echo "worldname=$TMOD_WORLDNAME" >> "$configPath"
     echo "autocreate=$TMOD_WORLDSIZE" >> "$configPath"
 fi


### PR DESCRIPTION
As described in issue #28, this users of this container have been experiencing several issues with getting the server to start and load mods properly. To solve this, I have rolled back the security changes made back as a suggestion from #12. To those concerned with container security, I reviewed several containers hosting game servers, and it seems like this configuration is common place. With that in mind, I made the necessary changes to support the maximum number of users with varying Docker implementations. 

In addition, I have taken the time to update the file directory structure to use a common /data directory. Mapping this directory to your host through the volumes compose configuration, or with the -v flag will preserve the downloaded workshop mods, and world files. This means that previous configurations will break, and users should update their environment variables to reflect.

This change in directory mapping has been communicated within the start script of the container to help ease you into the adjustment. 

Next, due to the impending tModLoader 1.4.4 release, I have placed a couple notices alerting of the high probability of this update breaking this container. Users should keep an eye on the Github repo for updates posted on top of the README and on the issues page as well for how to proceed.

Finally, there is a discord now! For those who want to chat or ask for support on configuring the container, please feel free to [join](https://discord.gg/dHnVYYGed7)! 