### PR TITLE
v2023.09.3.0 Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 RUN chown -R root:root /usr/bin/ /etc/ssl/certs /lib/ /usr/lib/
 
 RUN apt-get update \
-    && apt-get install -y wget unzip tmux bash libsdl2-2.0-0
+    && apt-get install -y wget unzip tmux bash libsdl2-2.0-0 libicu60
 
 RUN mkdir /data
 RUN mkdir /data/tModLoader


### PR DESCRIPTION
Trying to build the container to tModLoader v2023.09.3.0 would make the server not load at all.

The error log output tells us "Couldn't find a valid ICU package installed on the system".  We could tell it to ignore globalization, but installing the ICU package to support it seemed the better way to go.