### PR TITLE
Add redirect to allow for tty input.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,8 @@ RUN chmod 755 ./LaunchUtils/DotNetInstall.sh \
     && chmod 755 ./autosave.sh \
     && chmod 755 /usr/local/bin/inject \
     && chmod 755 ./prepare-config.sh \
-    && chmod 755 ./start-tModLoaderServer.sh
+    && chmod 755 ./start-tModLoaderServer.sh \
+    && chmod 755 ./redirect.sh
 
 RUN ./LaunchUtils/DotNetInstall.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,6 +100,9 @@ sleep 5s
 mkfifo $pipe
 tmux new-session -d "$server | tee $pipe"
 
+# Call the tty input redirect
+/terraria-server/redirect.sh &
+
 # Call the autosaver
 /terraria-server/autosave.sh &
 

--- a/redirect.sh
+++ b/redirect.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ ! -e "/dev/pts/0" ]; then
+    echo "tty not enabled"
+    exit 1
+fi
+
+if [ -e "/tmp/input" ]; then
+    rm /tmp/input
+fi
+
+mkfifo /tmp/input
+
+send_keys_to_tmux() {
+    while IFS= read -r line; do
+        tmux send-keys "$line" Enter
+    done
+}
+
+send_keys_to_tmux < /tmp/input &
+
+# Attempt to redirect input from the TTY to pipe
+cat < /dev/pts/0 > /tmp/input


### PR DESCRIPTION
Sometimes you will want to send input to the server via enabling the tty (`docker run -t') and writing terraria console commands there. This is more convenient than using `docker exec tmodloader inject`, but its not possible by default since nothing reads from the tty.

So I made a small script that will redirect input from the tty to a pipe and then send the lines from that pipe to tmux via `tmux send-keys`. Admittedly this workaround results in console commands that are inputed into the tty being printed twice, but I am not sure how to fix that.

![tty being used to input command in portainer](https://github.com/JACOBSMILE/tmodloader1.4/assets/53794934/fe6c1158-b166-43bd-89f6-8804402f321c)
