### PR TITLE
Remove obsolete version property from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   tmodloader:
     image: 'jacobsmile/tmodloader1.4:latest'


### PR DESCRIPTION
[docs.docker.com/reference/compose-file/version-and-name#version-top-level-element-obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)