### PR TITLE
Install missing ICU dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ COPY --from=builder /root/installer/linux32/libstdc++.so.6 /lib/
 RUN chown -R root:root /usr/bin/ /etc/ssl/certs /lib/ /usr/lib/
 
 RUN apt-get update \
-    && apt-get install -y wget unzip tmux bash libsdl2-2.0-0
+    && apt-get install -y wget unzip tmux bash libsdl2-2.0-0 libicu-dev
 
 RUN mkdir /data
 RUN mkdir /data/tModLoader


### PR DESCRIPTION
Fixes #90

Since .NET runtime fails to start without ICU support, the **libicu-dev** dependency is added to the Docker image.